### PR TITLE
Update buildkite template and pipeline configurations

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -1,1 +1,0 @@
-cat .buildkite/pipeline.yml | sed "s/\$BUILDKITE_AGENT_META_DATA_QUEUE/${BUILDKITE_AGENT_META_DATA_QUEUE:-default}/" | buildkite-agent pipeline upload

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 steps:
-  - name: ":console:"
+  - label: ":console:"
     command: "script.sh"
     parallelism: 5
     agents:
-      queue: $BUILDKITE_AGENT_META_DATA_QUEUE
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"

--- a/.buildkite/template.yml
+++ b/.buildkite/template.yml
@@ -1,5 +1,6 @@
 # Used by the 'Add to Buildkite' button in the readme
 name: "Bash Parallel Example"
+description: "An parallel example repository you can use as a test project with Buildkite"
 steps:
-  - command: ".buildkite/pipeline.sh"
+  - command: "buildkite-agent pipeline upload"
     label: ":pipeline:"


### PR DESCRIPTION
This example repository is partnered with [Elastic CI Stack tutorial](https://buildkite.com/docs/tutorials/elastic-ci-stack-aws). 

This PR:

- Remove `pipeline.sh`
- Fixed the `label` of command step and 
- Add missing description in template
- agent queue defaults to `default`